### PR TITLE
Update TransactionMessage+CoreDataClass.swift

### DIFF
--- a/sphinx/Core Data/TransactionMessage/TransactionMessage+CoreDataClass.swift
+++ b/sphinx/Core Data/TransactionMessage/TransactionMessage+CoreDataClass.swift
@@ -349,8 +349,13 @@ public class TransactionMessage: NSManagedObject {
         }
         
         if let chat = chat {
-            message.chat = chat
-            chat.setLastMessage(message)
+            if(message.chat == nil){
+                message.chat = chat
+                chat.setLastMessage(message)
+            }
+            else{
+                message.chat?.setLastMessage(message)
+            }
         }
         
         return message

--- a/sphinx/Core Data/TransactionMessage/TransactionMessage+CoreDataClass.swift
+++ b/sphinx/Core Data/TransactionMessage/TransactionMessage+CoreDataClass.swift
@@ -349,12 +349,11 @@ public class TransactionMessage: NSManagedObject {
         }
         
         if let chat = chat {
-            if(message.chat == nil){
+            if let chat = message.chat {
+                chat.setLastMessage(message)
+            } else {
                 message.chat = chat
                 chat.setLastMessage(message)
-            }
-            else{
-                message.chat?.setLastMessage(message)
             }
         }
         


### PR DESCRIPTION
Related to #216 . I believe the error is caused by trying to assign the chat value to message when it is already set

![image](https://github.com/stakwork/sphinx-ios/assets/96802642/499c7062-acf8-4551-be0d-4732e9adb478)
