### PR TITLE
Fix possible race condition that manifests about 1/4 to 1/10 of the time

### DIFF
--- a/sphinx/Scenes/Dashboard/Chats/ChatsCollectionViewController.swift
+++ b/sphinx/Scenes/Dashboard/Chats/ChatsCollectionViewController.swift
@@ -412,13 +412,14 @@ extension ChatsCollectionViewController : ChatListCollectionViewCellDelegate, Me
             return
         }
         
+        let desiredState = !chat.seen //store this immutable value and always sync both based on chat status
         API.sharedInstance.toggleChatReadUnread(
             chatId: chat.id,
-            shouldMarkAsUnread: lastMessage.seen,
+            shouldMarkAsUnread: desiredState == false,//mark as unread if we want "seen" to be false
             callback: { success in
                 if success {
-                    lastMessage.seen = !lastMessage.seen
-                    chat.seen = !chat.seen
+                    lastMessage.seen = desiredState
+                    chat.seen = desiredState
                     chat.saveChat()
                 } else {
                     DispatchQueue.main.async {

--- a/sphinx/Scenes/Dashboard/Chats/ChatsCollectionViewController.swift
+++ b/sphinx/Scenes/Dashboard/Chats/ChatsCollectionViewController.swift
@@ -407,12 +407,12 @@ extension ChatsCollectionViewController : ChatListCollectionViewCellDelegate, Me
     }
     
     func shouldToggleReadUnread(chat: Chat) {
-
         guard let lastMessage = chat.lastMessage else {
             return
         }
         
         let desiredState = !chat.seen //store this immutable value and always sync both based on chat status
+        
         API.sharedInstance.toggleChatReadUnread(
             chatId: chat.id,
             shouldMarkAsUnread: desiredState == false,//mark as unread if we want "seen" to be false


### PR DESCRIPTION
@tomastiminskas there is an intermittent reliability issue that I believe is caused by a race condition/chat & lastMessage getting out of sync. I resolved it by assigning them each to the same immutable value & it works 100% of the time in my test sample of about 25 trials.