### PR TITLE
Add balance masking

### DIFF
--- a/sphinx/Extensions/UserDefaults.swift
+++ b/sphinx/Extensions/UserDefaults.swift
@@ -13,6 +13,7 @@ extension UserDefaults {
         public static let lastSeenHistoryDate = DefaultKey<Date>("lastSeenHistoryDate")
         public static let lastSeenMessagesDate = DefaultKey<Date>("lastSeenMessagesDate")
         public static let lastSeenContactsDate = DefaultKey<Date>("lastSeenContactsDate")
+        public static let hideBalances = DefaultKey<Bool>("hideBalances")
         public static let channelBalance = DefaultKey<Int>("channelBalance")
         public static let remoteBalance = DefaultKey<Int>("remoteBalance")
         public static let currentIP = DefaultKey<String>("currentIP")

--- a/sphinx/Scenes/Chat/Custom Views/Chat/ChatListHeader.swift
+++ b/sphinx/Scenes/Chat/Custom Views/Chat/ChatListHeader.swift
@@ -50,6 +50,9 @@ class ChatListHeader: UIView {
         contentView.autoresizingMask = [.flexibleHeight, .flexibleWidth]
         
         upgradeAppButton.layer.cornerRadius = upgradeAppButton.frame.size.height / 2
+        
+        let balanceTap = UITapGestureRecognizer(target: self, action: #selector(self.balanceLabelTapped(gesture:)))
+        self.smallBalanceLabel.addGestureRecognizer(balanceTap)
     }
     
     func listenForEvents() {
@@ -180,6 +183,12 @@ class ChatListHeader: UIView {
     
     @IBAction func leftMenuButtonTouched() {
         delegate?.leftMenuButtonTouched()
+    }
+    
+    @objc private func balanceLabelTapped(gesture: UIGestureRecognizer) {
+        let hideBalances = UserDefaults.Keys.hideBalances.get(defaultValue: false)
+        UserDefaults.Keys.hideBalances.set(!hideBalances)
+        updateBalance()
     }
     
 }

--- a/sphinx/Scenes/Chat/Custom Views/Chat/ChatListHeader.xib
+++ b/sphinx/Scenes/Chat/Custom Views/Chat/ChatListHeader.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -42,7 +42,7 @@
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xgc-Ie-Ybe">
                     <rect key="frame" x="0.0" y="0.0" width="414" height="50"/>
                     <subviews>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gpu-Jm-JpQ">
+                        <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gpu-Jm-JpQ">
                             <rect key="frame" x="207" y="25" width="0.0" height="0.0"/>
                             <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="17"/>
                             <color key="textColor" name="Text"/>

--- a/sphinx/Scenes/Left Menu/Base.lproj/LeftMenu.storyboard
+++ b/sphinx/Scenes/Left Menu/Base.lproj/LeftMenu.storyboard
@@ -61,7 +61,7 @@
                                             <constraint firstAttribute="height" constant="19" id="toc-Rx-RC6"/>
                                         </constraints>
                                     </imageView>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jUZ-jZ-gCS">
+                                    <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jUZ-jZ-gCS">
                                         <rect key="frame" x="75" y="81" width="9" height="17"/>
                                         <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="14"/>
                                         <color key="textColor" name="Text"/>

--- a/sphinx/Scenes/Left Menu/LeftMenuViewController.swift
+++ b/sphinx/Scenes/Left Menu/LeftMenuViewController.swift
@@ -105,7 +105,9 @@ class LeftMenuViewController: UIViewController {
         configureProfile()
         configureTable()
         configureKarmaPurchaseButton()
-        walletBalanceService.updateBalance(labels: [balanceLabel])
+        let balanceTap = UITapGestureRecognizer(target: self, action: #selector(self.balanceLabelTapped(gesture:)))
+        self.balanceLabel.addGestureRecognizer(balanceTap)
+        updateBalance()
     }
     
     func configureProfile() {
@@ -207,6 +209,16 @@ class LeftMenuViewController: UIViewController {
         }
         startPurchaseProgressIndicator()
         storeKitService.purchase(karmaPurchaseProduct)
+    }
+    
+    private func updateBalance() {
+        walletBalanceService.updateBalance(labels: [balanceLabel])
+    }
+    
+    @objc private func balanceLabelTapped(gesture: UIGestureRecognizer) {
+        let hideBalances = UserDefaults.Keys.hideBalances.get(defaultValue: false)
+        UserDefaults.Keys.hideBalances.set(!hideBalances)
+        updateBalance()
     }
 }
 

--- a/sphinx/Scenes/Profile/Base.lproj/Profile.storyboard
+++ b/sphinx/Scenes/Profile/Base.lproj/Profile.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="dark"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -983,7 +983,7 @@
                                         <color key="textColor" name="Text"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="B43-2h-mk8">
+                                    <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="B43-2h-mk8">
                                         <rect key="frame" x="143" y="132" width="7" height="15"/>
                                         <fontDescription key="fontDescription" name="Montserrat-Regular" family="Montserrat" pointSize="12"/>
                                         <color key="textColor" name="Text"/>

--- a/sphinx/Scenes/Profile/ProfileViewController.swift
+++ b/sphinx/Scenes/Profile/ProfileViewController.swift
@@ -142,7 +142,9 @@ class ProfileViewController: NewKeyboardHandlerViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        walletBalanceService.updateBalance(labels: [balanceLabel])
+        let balanceTap = UITapGestureRecognizer(target: self, action: #selector(self.balanceLabelTapped(gesture:)))
+        self.balanceLabel.addGestureRecognizer(balanceTap)
+        updateBalance()
     }
     
     override func keyboardWillShowHandler(_ notification: Notification) {
@@ -437,6 +439,16 @@ class ProfileViewController: NewKeyboardHandlerViewController {
         let _ = notificationSoundHelper.selectUserSound(file: UserContact.getOwner()?.notificationSound)
         let notificationSoundVC = NotificationSoundViewController.instantiate(helper: notificationSoundHelper, delegate: self)
         self.navigationController?.pushViewController(notificationSoundVC, animated: true)
+    }
+    
+    private func updateBalance() {
+        walletBalanceService.updateBalance(labels: [balanceLabel])
+    }
+    
+    @objc private func balanceLabelTapped(gesture: UIGestureRecognizer) {
+        let hideBalances = UserDefaults.Keys.hideBalances.get(defaultValue: false)
+        UserDefaults.Keys.hideBalances.set(!hideBalances)
+        updateBalance()
     }
     
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/sphinx/Services/WalletBalanceService.swift
+++ b/sphinx/Services/WalletBalanceService.swift
@@ -59,10 +59,15 @@ public final class WalletBalanceService {
         }
     }
     
-    func updateLabels(labels: [UILabel], balance: String) {
+    private func updateLabels(labels: [UILabel], balance: String) {
         DispatchQueue.main.async {
+            let hideBalances = UserDefaults.Keys.hideBalances.get(defaultValue: false)
             for label in labels {
-                label.text = balance
+                if (hideBalances) {
+                    label.text = "＊＊＊＊＊"
+                } else {
+                    label.text = balance
+                }
             }
         }
     }


### PR DESCRIPTION
Performs the masking in WalletBalanceService since it is already designed to set text on balance labels.  Tapping on the balanceLabel in LeftMenu, ProfileView, or ChatListHeader causes the UserDefault balanceMask to toggle the mask for all 3 views and to persist on app close.

<img width="441" alt="Screenshot 2024-02-19 at 9 13 28 PM" src="https://github.com/stakwork/sphinx-ios/assets/11140095/db4b8ea6-ec0e-4ccf-bd28-aca40af68c43">
<img width="430" alt="Screenshot 2024-02-19 at 9 13 14 PM" src="https://github.com/stakwork/sphinx-ios/assets/11140095/8d178817-b72b-4372-8eae-c91ea1bc7d8f">
<img width="419" alt="Screenshot 2024-02-19 at 9 13 06 PM" src="https://github.com/stakwork/sphinx-ios/assets/11140095/d6e52dc9-d076-409b-80f0-97d3b1b3944a">

