### PR TITLE
Episode Detail View Height

### DIFF
--- a/sphinx/Scenes/Dashboard/Base.lproj/Dashboard.storyboard
+++ b/sphinx/Scenes/Dashboard/Base.lproj/Dashboard.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="dark"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -279,11 +279,8 @@
                                 <rect key="frame" x="0.0" y="48" width="414" height="848"/>
                                 <subviews>
                                     <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="37K-dr-aGI">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="520"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="706"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="520" id="wbB-x7-7kN"/>
-                                        </constraints>
                                         <color key="sectionIndexBackgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     </tableView>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Re9-Eb-2Gh">
@@ -303,6 +300,7 @@
                                 </subviews>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
+                                    <constraint firstItem="Re9-Eb-2Gh" firstAttribute="top" secondItem="37K-dr-aGI" secondAttribute="bottom" constant="10" id="2wi-Ix-u2l"/>
                                     <constraint firstItem="Re9-Eb-2Gh" firstAttribute="leading" secondItem="7Et-PE-60b" secondAttribute="leading" id="AbN-MW-iSB"/>
                                     <constraint firstItem="37K-dr-aGI" firstAttribute="top" secondItem="7Et-PE-60b" secondAttribute="top" id="RCM-uy-qNK"/>
                                     <constraint firstAttribute="trailing" secondItem="37K-dr-aGI" secondAttribute="trailing" id="ikV-cV-HTz"/>

--- a/sphinx/Scenes/WebAppsAndPodcasts/Data Sources/FeedItemDetailVM.swift
+++ b/sphinx/Scenes/WebAppsAndPodcasts/Data Sources/FeedItemDetailVM.swift
@@ -97,7 +97,7 @@ class FeedItemDetailVM : NSObject {
         tableView?.dataSource = self
         
         DelayPerformedHelper.performAfterDelay(seconds: 0.1, completion: {
-            self.tableView?.scrollToBottom()
+            self.tableView?.scrollToTop()
         })
     }
     


### PR DESCRIPTION
# Pull Request Title
## Podcast/Video episode details view height https://github.com/stakwork/sphinx-ios/issues/437

### Description
This pull request addresses the Podcast/Video episode details view height in Issue https://github.com/stakwork/sphinx-ios/issues/437.

### The following are the addressed issues:
- Episode details view height does not fill entire height of the view forcing user to scroll when it's not actually needed

## Changes Made
- Dashboard.storyboard
    - FeedItemDetailVC storyboard
        - Delete the table view height constraint
        - Set the bottom anchor of the table view to the top of the close button